### PR TITLE
add an experimental "name" to routes

### DIFF
--- a/src/match.rs
+++ b/src/match.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, ops::Deref};
+use std::{cmp::Ordering, fmt::Debug, ops::Deref};
 
 use crate::{Capture, Captures, Route, RouteSpec, Segment};
 
@@ -8,16 +8,19 @@ use crate::{Capture, Captures, Route, RouteSpec, Segment};
 /// It dereferences to the contained type T
 
 #[derive(Debug)]
-pub struct Match<'router, 'path, T> {
+pub struct Match<'router, 'path, T, N = ()> {
     path: &'path str,
-    route: &'router Route<T>,
+    route: &'router Route<T, N>,
     captures: Vec<&'path str>,
 }
 
-impl<'router, 'path, T> Match<'router, 'path, T> {
+impl<'router, 'path, T, N> Match<'router, 'path, T, N>
+where
+    N: Debug,
+{
     /// Attempts to build a new Match from the provided path string
     /// and route. Returns None if the match was unsuccessful
-    pub fn new(path: &'path str, route: &'router Route<T>) -> Option<Self> {
+    pub fn new(path: &'path str, route: &'router Route<T, N>) -> Option<Self> {
         let mut p = path.trim_start_matches('/').trim_end_matches('/');
         let mut captures = vec![];
 
@@ -123,27 +126,39 @@ impl<'router, 'path, T> Match<'router, 'path, T> {
     }
 }
 
-impl<'router, 'path, T> PartialEq for Match<'router, 'path, T> {
+impl<'router, 'path, T, N> PartialEq for Match<'router, 'path, T, N>
+where
+    N: Debug,
+{
     fn eq(&self, other: &Self) -> bool {
         *other.route == *self.route
     }
 }
 
-impl<'router, 'path, T> Eq for Match<'router, 'path, T> {}
+impl<'router, 'path, T, N> Eq for Match<'router, 'path, T, N> where N: Debug {}
 
-impl<'router, 'path, T> PartialOrd for Match<'router, 'path, T> {
+impl<'router, 'path, T, N> PartialOrd for Match<'router, 'path, T, N>
+where
+    N: Debug,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'router, 'path, T> Ord for Match<'router, 'path, T> {
+impl<'router, 'path, T, N> Ord for Match<'router, 'path, T, N>
+where
+    N: Debug,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         self.route.cmp(&other.route)
     }
 }
 
-impl<'router, 'path, T> Deref for Match<'router, 'path, T> {
+impl<'router, 'path, T, N> Deref for Match<'router, 'path, T, N>
+where
+    N: Debug,
+{
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/src/reverse_match.rs
+++ b/src/reverse_match.rs
@@ -1,20 +1,23 @@
-use std::ops::Deref;
+use std::{fmt::Debug, ops::Deref};
 
 use crate::{Captures, Route, Segment};
 /// This struct represents the result of a reverse lookup from
 /// [`Captures`] to a [`Route`]
 #[derive(Debug, Clone, Copy)]
-pub struct ReverseMatch<'keys, 'values, 'captures, 'route, T> {
-    route: &'route Route<T>,
+pub struct ReverseMatch<'keys, 'values, 'captures, 'route, T, N> {
+    route: &'route Route<T, N>,
     captures: &'captures Captures<'keys, 'values>,
 }
 
-impl<'keys, 'values, 'captures, 'route, T> ReverseMatch<'keys, 'values, 'captures, 'route, T> {
+impl<'keys, 'values, 'captures, 'route, T, N> ReverseMatch<'keys, 'values, 'captures, 'route, T, N>
+where
+    N: Debug,
+{
     /// Attempts to build a new ReverseMatch. Returns None if the
     /// match was unsuccessful.
     pub fn new(
         captures: &'captures Captures<'keys, 'values>,
-        route: &'route Route<T>,
+        route: &'route Route<T, N>,
     ) -> Option<Self> {
         let all_params_matched = route
             .segments()
@@ -39,7 +42,7 @@ impl<'keys, 'values, 'captures, 'route, T> ReverseMatch<'keys, 'values, 'capture
     }
 
     /// Returns the Route for this ReverseMatch
-    pub fn route(&self) -> &Route<T> {
+    pub fn route(&self) -> &Route<T, N> {
         &self.route
     }
 
@@ -49,8 +52,10 @@ impl<'keys, 'values, 'captures, 'route, T> ReverseMatch<'keys, 'values, 'capture
     }
 }
 
-impl<'keys, 'values, 'captures, 'route, T> std::fmt::Display
-    for ReverseMatch<'keys, 'values, 'captures, 'route, T>
+impl<'keys, 'values, 'captures, 'route, T, N> std::fmt::Display
+    for ReverseMatch<'keys, 'values, 'captures, 'route, T, N>
+where
+    N: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("/")?;
@@ -67,8 +72,10 @@ impl<'keys, 'values, 'captures, 'route, T> std::fmt::Display
     }
 }
 
-impl<'keys, 'values, 'captures, 'route, T> Deref
-    for ReverseMatch<'keys, 'values, 'captures, 'route, T>
+impl<'keys, 'values, 'captures, 'route, T, N> Deref
+    for ReverseMatch<'keys, 'values, 'captures, 'route, T, N>
+where
+    N: Debug,
 {
     type Target = T;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -198,3 +198,42 @@ fn reverse_lookup() -> Result {
 
     Ok(())
 }
+
+#[test]
+pub fn named_routes() {
+    let mut router = Router::default();
+    router
+        .add_named("/users/:user_id", (), "user_show")
+        .unwrap();
+
+    assert!(router.get_named("user_show").is_some());
+
+    assert_eq!(
+        router["user_show"]
+            .template(&Captures::from(vec![("user_id", "10")]))
+            .unwrap(),
+        "/users/10"
+    )
+}
+
+#[test]
+pub fn named_routes_with_enum() {
+    #[derive(Debug, PartialEq)]
+    enum Routes {
+        UsersShow,
+    }
+
+    let mut router = Router::default();
+    router
+        .add_named("/users/:user_id", (), Routes::UsersShow)
+        .unwrap();
+
+    assert!(router.get_named(Routes::UsersShow).is_some());
+
+    assert_eq!(
+        router[Routes::UsersShow]
+            .template(&Captures::from(vec![("user_id", "10")]))
+            .unwrap(),
+        "/users/10"
+    )
+}


### PR DESCRIPTION
where name can be any type that's Debug, adding support for enum-named routes as well as string-named routes