### PR TITLE
The lower bound is 0

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -240,6 +240,6 @@ impl<'a, 'b, Handler> Iterator for MatchIter<'a, 'b, Handler> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        (0, self.iter.size_hint().1)
     }
 }


### PR DESCRIPTION
By filtering, we may return as few as 0 elements.
In fact, we realistically *never* match *all* the `RouteSpec`s.

This, and a lot more, could be obtained automatically by doing
```rs
fn match_iter<'r, 'p>(
    &'r self,
    path: &'p str,
) -> impl Iterator<Item = Match<'r, 'p, Handler>> + DoubleEndedIterator + FusedIterator {
    self.routes.iter().filter_map(move |(route, handler)| {
        route.matches(path).map(|captures| Match {
            path,
            route,
            captures,
            handler,
        })
    })
}
```
but that's more of a breaking change since the `MatchIter` will be desutroid.

This, in turn, is fixed by 
```rs
type MatchIter<'r, 'p, H: 'r> = impl Iterator<Item = Match<'r, 'p, H>> + DoubleEndedIterator + FusedIterator;

fn match_iter<'r, 'p>(&'r self, path: &'p str) -> MatchIter<'r, 'p, Handler> {
```
but that's not even stable, requiring `#![feature(type_alias_impl_trait)]` 