### PR TITLE
feat: minimum length check

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,17 +1,19 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
-
-use routefinder::*;
+use routefinder::Router;
 
 fn benchmark(c: &mut Criterion) {
-    let mut router = Router::new();
-    router.add("/posts/:post_id/comments/:id", 1).unwrap();
-    router.add("/posts/:post_id/comments", 2).unwrap();
-    router.add("/posts/:post_id", 3).unwrap();
-    router.add("/posts", 4).unwrap();
-    router.add("/comments", 5).unwrap();
-    router.add("/comments/:id", 6).unwrap();
-    router.add("/*", 7).unwrap();
+    let router = Router::new_with_routes([
+        ("/posts/:post_id/comments/:id", 1),
+        ("/posts/:post_id/comments", 2),
+        ("/posts/:post_id", 3),
+        ("/posts", 4),
+        ("/comments", 5),
+        ("/comments/:id", 6),
+        ("/*", 7),
+    ])
+    .unwrap();
+
+    dbg!(&router);
 
     c.bench_function("/posts/n/comments/n", |b| {
         b.iter(|| router.best_match("/posts/100/comments/200"))
@@ -21,24 +23,18 @@ fn benchmark(c: &mut Criterion) {
         b.iter(|| router.best_match("/posts/100/comments"))
     });
 
-    c.bench_function("/posts/n", |b| {
-        b.iter(|| router.best_match(black_box("/posts/100")))
-    });
+    c.bench_function("/posts/n", |b| b.iter(|| router.best_match("/posts/100")));
 
-    c.bench_function("/posts", |b| {
-        b.iter(|| router.best_match(black_box("/posts")))
-    });
+    c.bench_function("/posts", |b| b.iter(|| router.best_match("/posts")));
 
-    c.bench_function("/comments", |b| {
-        b.iter(|| router.best_match(black_box("/comments")))
-    });
+    c.bench_function("/comments", |b| b.iter(|| router.best_match("/comments")));
 
     c.bench_function("/comments/n", |b| {
-        b.iter(|| router.best_match(black_box("/comments/100")))
+        b.iter(|| router.best_match("/comments/100"))
     });
 
     c.bench_function("fallthrough", |b| {
-        b.iter(|| router.best_match(black_box("/a/b/c/d/e/f")))
+        b.iter(|| router.best_match("/a/b/c/d/e/f"))
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,3 +57,6 @@ pub use reverse_match::ReverseMatch;
 
 mod route_spec;
 pub use route_spec::RouteSpec;
+
+mod path;
+pub(crate) use path::Path;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,13 @@
+/// A path to be tested against the router.
+#[derive(Debug)]
+pub(crate) struct Path<'a> {
+    pub(crate) str: &'a str,
+    pub(crate) trimmed: &'a str,
+}
+
+impl<'a> From<&'a str> for Path<'a> {
+    fn from(str: &'a str) -> Self {
+        let trimmed = str.trim_start_matches('/').trim_end_matches('/');
+        Self { str, trimmed }
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,13 +5,14 @@ use routefinder::*;
 
 #[test]
 fn it_works() -> Result {
-    let mut router = Router::new();
-    router.add("/*", 1)?;
-    router.add("/hello", 2)?;
-    router.add("/:greeting", 3)?;
-    router.add("/hey/:world", 4)?;
-    router.add("/hey/earth", 5)?;
-    router.add("/:greeting/:world/*", 6)?;
+    let router = Router::new_with_routes([
+        ("/*", 1),
+        ("/hello", 2),
+        ("/:greeting", 3),
+        ("/hey/:world", 4),
+        ("/hey/earth", 5),
+        ("/:greeting/:world/*", 6),
+    ])?;
 
     assert_eq!(
         &format!("{:#?}", &router),
@@ -52,11 +53,12 @@ fn it_works() -> Result {
 
 #[test]
 fn several_params() -> Result {
-    let mut router = Router::new();
-    router.add("/:a", 1)?;
-    router.add("/:a/:b", 2)?;
-    router.add("/:a/:b/:c", 3)?;
-    router.add("/:param1/specific/:param2", 4)?;
+    let router = Router::new_with_routes([
+        ("/:a", 1),
+        ("/:a/:b", 2),
+        ("/:a/:b/:c", 3),
+        ("/:param1/specific/:param2", 4),
+    ])?;
     assert_eq!(*router.best_match("/hi").unwrap(), 1);
     assert_eq!(*router.best_match("/hi/there").unwrap(), 2);
     assert_eq!(*router.best_match("/hi/there/hey").unwrap(), 3);
@@ -73,16 +75,13 @@ fn several_params() -> Result {
 
 #[test]
 fn wildcard_matches_root() -> Result {
-    let mut router = Router::new();
-    router.add("*", ())?;
+    let router = Router::new_with_routes([("*", ())])?;
     assert!(router.best_match("/").is_some());
 
-    let mut router = Router::new();
-    router.add("/something/:anything/*", ())?;
+    let router = Router::new_with_routes([("/something/:anything/*", ())])?;
     assert!(router.best_match("/something/1/").is_some());
 
-    let mut router = Router::new();
-    router.add("/something/:anything/*", ())?;
+    let router = Router::new_with_routes([("/something/:anything/*", ())])?;
     assert!(router.best_match("/something/1").is_some());
 
     Ok(())
@@ -90,13 +89,11 @@ fn wildcard_matches_root() -> Result {
 
 #[test]
 fn trailing_slashes_are_ignored() -> Result {
-    let mut router = Router::new();
-    router.add("/a", ())?;
+    let router = Router::new_with_routes([("/a", ())])?;
     assert!(router.best_match("/a/").is_some());
     assert!(router.best_match("/a").is_some());
 
-    let mut router = Router::new();
-    router.add("/a/", ())?;
+    let router = Router::new_with_routes([("/a/", ())])?;
     assert!(router.best_match("/a").is_some());
     assert!(router.best_match("/a/").is_some());
 
@@ -105,8 +102,7 @@ fn trailing_slashes_are_ignored() -> Result {
 
 #[test]
 fn captures() -> Result {
-    let mut router = Router::new();
-    router.add("/:a/:b/:c", ())?;
+    let router = Router::new_with_routes([("/:a/:b/:c", ())])?;
     let best_match = router.best_match("/aaa/bbb/ccc").unwrap();
     let captures = best_match.captures();
     assert_eq!(captures.get("a"), Some("aaa"));
@@ -114,8 +110,7 @@ fn captures() -> Result {
     assert_eq!(captures.get("c"), Some("ccc"));
     assert_eq!(captures.get("not-present"), None);
 
-    let mut router = Router::new();
-    router.add("/*", ())?;
+    let router = Router::new_with_routes([("/*", ())])?;
     let best_match = router.best_match("/hello/world").unwrap();
     assert_eq!(best_match.captures().wildcard(), Some("hello/world"));
 
@@ -136,11 +131,12 @@ fn errors_on_add() {
 
 #[test]
 fn dots() -> Result {
-    let mut router = Router::new();
-    router.add("/:a.:b", 1)?;
-    router.add("/:a/:b.:c", 2)?;
-    router.add("/:a/:b", 3)?;
-    router.add("/:a/:b.txt", 4)?;
+    let router = Router::new_with_routes([
+        ("/:a.:b", 1),
+        ("/:a/:b.:c", 2),
+        ("/:a/:b", 3),
+        ("/:a/:b.txt", 4),
+    ])?;
     assert_eq!(*router.best_match("/hello.world").unwrap(), 1);
     assert_eq!(*router.best_match("/hi/there.world").unwrap(), 2);
     assert_eq!(*router.best_match("/hi/yep").unwrap(), 3);


### PR DESCRIPTION
This represents an optimization that allows for an early exit if the test path is shorter than the minimum length of a path. It also introduces a crate-private Path struct that allows us to cache any calculations that would apply to all routespecs. For now, it is only used to avoid trimming leading and trailing slashes once per routespec. We also cache the number of dots in a routespec.